### PR TITLE
Add rally job for noiro

### DIFF
--- a/install_rally.sh
+++ b/install_rally.sh
@@ -35,8 +35,8 @@ PYTHON=${PYTHON2:-$PYTHON3}
 VIRTUALENV_VERSION="15.1.0"
 VIRTUALENV_URL="https://raw.github.com/pypa/virtualenv/$VIRTUALENV_VERSION/virtualenv.py"
 
-RALLY_GIT_URL="https://git.openstack.org/openstack/rally"
-RALLY_GIT_BRANCH="master"
+RALLY_GIT_URL="https://github.com/noironetworks/rally"
+RALLY_GIT_BRANCH="noiro-master"
 RALLY_CONFIGURATION_DIR=/etc/rally
 RALLY_DATABASE_DIR=/var/lib/rally/database
 DBTYPE=sqlite

--- a/rally-jobs/rally-gate.json
+++ b/rally-jobs/rally-gate.json
@@ -1,0 +1,545 @@
+{
+  "version": 2, 
+  "title": "", 
+  "description": "", 
+  "subtasks": [
+    {
+      "title": "NeutronNetworks.create_and_list_networks", 
+      "description": "", 
+      "workloads": [
+        {
+          "scenario": {
+            "NeutronNetworks.create_and_list_networks": {}
+          }, 
+          "description": "Create a network and then list all networks.", 
+          "contexts": {
+            "users": {
+              "users_per_tenant": 1, 
+              "tenants": 1
+            }, 
+            "quotas": {
+              "neutron": {
+                "network": 119
+              }
+            }
+          }, 
+          "runner": {
+            "constant": {
+              "concurrency": 20, 
+              "times": 100
+            }
+          }, 
+          "hooks": [], 
+          "sla": {
+            "max_avg_duration_per_atomic": {
+              "neutron.list_networks": 15
+            }, 
+            "failure_rate": {
+              "max": 0
+            }
+          }
+        }
+      ]
+    }, 
+    {
+      "title": "NeutronNetworks.create_and_list_subnets", 
+      "description": "", 
+      "workloads": [
+        {
+          "scenario": {
+            "NeutronNetworks.create_and_list_subnets": {
+              "subnets_per_network": 2
+            }
+          }, 
+          "description": "Create and a given number of subnets and list all subnets.", 
+          "contexts": {
+            "users": {
+              "users_per_tenant": 1, 
+              "tenants": 1
+            }, 
+            "quotas": {
+              "neutron": {
+                "subnet": -1, 
+                "network": -1
+              }
+            }
+          }, 
+          "runner": {
+            "constant": {
+              "concurrency": 20, 
+              "times": 40
+            }
+          }, 
+          "hooks": [], 
+          "sla": {
+            "failure_rate": {
+              "max": 0
+            }
+          }
+        }
+      ]
+    }, 
+    {
+      "title": "NeutronNetworks.create_and_list_routers", 
+      "description": "", 
+      "workloads": [
+        {
+          "scenario": {
+            "NeutronNetworks.create_and_list_routers": {
+              "network_create_args": null, 
+              "subnet_cidr_start": "1.1.0.0/30", 
+              "subnets_per_network": 1, 
+              "subnet_create_args": null, 
+              "router_create_args": null
+            }
+          }, 
+          "description": "Create and a given number of routers and list all routers.", 
+          "contexts": {
+            "users": {
+              "users_per_tenant": 1, 
+              "tenants": 1
+            }, 
+            "quotas": {
+              "neutron": {
+                "subnet": -1, 
+                "network": -1, 
+                "router": -1
+              }
+            }
+          }, 
+          "runner": {
+            "constant": {
+              "concurrency": 20, 
+              "times": 40
+            }
+          }, 
+          "hooks": [], 
+          "sla": {
+            "failure_rate": {
+              "max": 0
+            }
+          }
+        }
+      ]
+    }, 
+    {
+      "title": "NeutronNetworks.create_and_list_ports", 
+      "description": "", 
+      "workloads": [
+        {
+          "scenario": {
+            "NeutronNetworks.create_and_list_ports": {
+              "network_create_args": null, 
+              "ports_per_network": 50, 
+              "port_create_args": null
+            }
+          }, 
+          "description": "Create and a given number of ports and list all ports.", 
+          "contexts": {
+            "users": {
+              "users_per_tenant": 1, 
+              "tenants": 1
+            }, 
+            "quotas": {
+              "neutron": {
+                "port": 811, 
+                "subnet": -1, 
+                "network": -1, 
+                "router": -1
+              }
+            }
+          }, 
+          "runner": {
+            "constant": {
+              "concurrency": 4, 
+              "times": 8
+            }
+          }, 
+          "hooks": [], 
+          "sla": {
+            "max_avg_duration_per_atomic": {
+              "neutron.list_ports": 15
+            }, 
+            "failure_rate": {
+              "max": 0
+            }
+          }
+        }
+      ]
+    }, 
+    {
+      "title": "NeutronNetworks.create_and_update_networks", 
+      "description": "", 
+      "workloads": [
+        {
+          "scenario": {
+            "NeutronNetworks.create_and_update_networks": {
+              "network_create_args": {}, 
+              "network_update_args": {
+                "name": "_updated", 
+                "admin_state_up": false
+              }
+            }
+          }, 
+          "description": "Create and update a network.", 
+          "contexts": {
+            "users": {
+              "users_per_tenant": 1, 
+              "tenants": 1
+            }, 
+            "quotas": {
+              "neutron": {
+                "network": -1
+              }
+            }
+          }, 
+          "runner": {
+            "constant": {
+              "concurrency": 20, 
+              "times": 40
+            }
+          }, 
+          "hooks": [], 
+          "sla": {
+            "failure_rate": {
+              "max": 0
+            }
+          }
+        }
+      ]
+    }, 
+    {
+      "title": "NeutronNetworks.create_and_update_subnets", 
+      "description": "", 
+      "workloads": [
+        {
+          "scenario": {
+            "NeutronNetworks.create_and_update_subnets": {
+              "network_create_args": {}, 
+              "subnet_cidr_start": "1.4.0.0/16", 
+              "subnets_per_network": 2, 
+              "subnet_create_args": {}, 
+              "subnet_update_args": {
+                "name": "_subnet_updated", 
+                "enable_dhcp": true
+              }
+            }
+          }, 
+          "description": "Create and update a subnet.", 
+          "contexts": {
+            "users": {
+              "users_per_tenant": 5, 
+              "tenants": 1
+            }, 
+            "quotas": {
+              "neutron": {
+                "subnet": -1, 
+                "network": -1, 
+                "port": -1
+              }
+            }
+          }, 
+          "runner": {
+            "constant": {
+              "concurrency": 20, 
+              "times": 100
+            }
+          }, 
+          "hooks": [], 
+          "sla": {
+            "failure_rate": {
+              "max": 0
+            }
+          }
+        }
+      ]
+    }, 
+    {
+      "title": "NeutronNetworks.create_and_update_routers", 
+      "description": "", 
+      "workloads": [
+        {
+          "scenario": {
+            "NeutronNetworks.create_and_update_routers": {
+              "subnets_per_network": 1, 
+              "subnet_cidr_start": "1.1.0.0/30", 
+              "network_create_args": {}, 
+              "subnet_create_args": {}, 
+              "router_update_args": {
+                "name": "_router_updated", 
+                "admin_state_up": false
+              }, 
+              "router_create_args": {}
+            }
+          }, 
+          "description": "Create and update a given number of routers.", 
+          "contexts": {
+            "users": {
+              "users_per_tenant": 1, 
+              "tenants": 1
+            }, 
+            "quotas": {
+              "neutron": {
+                "subnet": -1, 
+                "network": -1, 
+                "router": -1
+              }
+            }
+          }, 
+          "runner": {
+            "constant": {
+              "concurrency": 20, 
+              "times": 40
+            }
+          }, 
+          "hooks": [], 
+          "sla": {
+            "failure_rate": {
+              "max": 0
+            }
+          }
+        }
+      ]
+    }, 
+    {
+      "title": "NeutronNetworks.create_and_update_ports", 
+      "description": "", 
+      "workloads": [
+        {
+          "scenario": {
+            "NeutronNetworks.create_and_update_ports": {
+              "network_create_args": {}, 
+              "ports_per_network": 5, 
+              "port_create_args": {}, 
+              "port_update_args": {
+                "device_owner": "dummy_owner", 
+                "device_id": "dummy_id", 
+                "name": "_port_updated", 
+                "admin_state_up": false
+              }
+            }
+          }, 
+          "description": "Create and update a given number of ports.", 
+          "contexts": {
+            "users": {
+              "users_per_tenant": 1, 
+              "tenants": 1
+            }, 
+            "quotas": {
+              "neutron": {
+                "network": -1, 
+                "port": -1
+              }
+            }
+          }, 
+          "runner": {
+            "constant": {
+              "concurrency": 20, 
+              "times": 40
+            }
+          }, 
+          "hooks": [], 
+          "sla": {
+            "failure_rate": {
+              "max": 0
+            }
+          }
+        }
+      ]
+    }, 
+    {
+      "title": "NeutronNetworks.create_and_delete_networks", 
+      "description": "", 
+      "workloads": [
+        {
+          "scenario": {
+            "NeutronNetworks.create_and_delete_networks": {
+              "network_create_args": {}
+            }
+          }, 
+          "description": "Create and delete a network.", 
+          "contexts": {
+            "users": {
+              "users_per_tenant": 1, 
+              "tenants": 1
+            }, 
+            "quotas": {
+              "neutron": {
+                "subnet": -1, 
+                "network": -1
+              }
+            }
+          }, 
+          "runner": {
+            "constant": {
+              "concurrency": 20, 
+              "times": 40
+            }
+          }, 
+          "hooks": [], 
+          "sla": {
+            "failure_rate": {
+              "max": 0
+            }
+          }
+        }
+      ]
+    }, 
+    {
+      "title": "NeutronNetworks.create_and_delete_subnets", 
+      "description": "", 
+      "workloads": [
+        {
+          "scenario": {
+            "NeutronNetworks.create_and_delete_subnets": {
+              "network_create_args": {}, 
+              "subnet_cidr_start": "1.1.0.0/30", 
+              "subnets_per_network": 2, 
+              "subnet_create_args": {}
+            }
+          }, 
+          "description": "Create and delete a given number of subnets.", 
+          "contexts": {
+            "users": {
+              "users_per_tenant": 1, 
+              "tenants": 1
+            }, 
+            "quotas": {
+              "neutron": {
+                "subnet": -1, 
+                "network": -1
+              }
+            }
+          }, 
+          "runner": {
+            "constant": {
+              "concurrency": 20, 
+              "times": 40
+            }
+          }, 
+          "hooks": [], 
+          "sla": {
+            "failure_rate": {
+              "max": 0
+            }
+          }
+        }
+      ]
+    }, 
+    {
+      "title": "NeutronNetworks.create_and_delete_routers", 
+      "description": "", 
+      "workloads": [
+        {
+          "scenario": {
+            "NeutronNetworks.create_and_delete_routers": {
+              "network_create_args": {}, 
+              "subnet_cidr_start": "1.1.0.0/30", 
+              "subnets_per_network": 1, 
+              "subnet_create_args": {}, 
+              "router_create_args": {}
+            }
+          }, 
+          "description": "Create and delete a given number of routers.", 
+          "contexts": {
+            "users": {
+              "users_per_tenant": 1, 
+              "tenants": 1
+            }, 
+            "quotas": {
+              "neutron": {
+                "subnet": -1, 
+                "network": -1, 
+                "router": -1
+              }
+            }
+          }, 
+          "runner": {
+            "constant": {
+              "concurrency": 20, 
+              "times": 40
+            }
+          }, 
+          "hooks": [], 
+          "sla": {
+            "failure_rate": {
+              "max": 0
+            }
+          }
+        }
+      ]
+    }, 
+    {
+      "title": "NeutronNetworks.create_and_delete_ports", 
+      "description": "", 
+      "workloads": [
+        {
+          "scenario": {
+            "NeutronNetworks.create_and_delete_ports": {
+              "network_create_args": {}, 
+              "ports_per_network": 5, 
+              "port_create_args": {}
+            }
+          }, 
+          "description": "Create and delete a port.", 
+          "contexts": {
+            "users": {
+              "users_per_tenant": 1, 
+              "tenants": 1
+            }, 
+            "quotas": {
+              "neutron": {
+                "network": -1, 
+                "port": -1
+              }
+            }
+          }, 
+          "runner": {
+            "constant": {
+              "concurrency": 20, 
+              "times": 40
+            }
+          }, 
+          "hooks": [], 
+          "sla": {
+            "failure_rate": {
+              "max": 0
+            }
+          }
+        }
+      ]
+    }, 
+    {
+      "title": "Quotas.neutron_update", 
+      "description": "", 
+      "workloads": [
+        {
+          "scenario": {
+            "Quotas.neutron_update": {
+              "max_quota": 1024
+            }
+          }, 
+          "description": "Update quotas for neutron.", 
+          "contexts": {
+            "users": {
+              "users_per_tenant": 1, 
+              "tenants": 20
+            }
+          }, 
+          "runner": {
+            "constant": {
+              "concurrency": 20, 
+              "times": 40
+            }
+          }, 
+          "hooks": [], 
+          "sla": {
+            "failure_rate": {
+              "max": 0
+            }
+          }
+        }
+      ]
+    } 
+  ]
+}

--- a/rally-jobs/rally-noiro-neutron.yaml
+++ b/rally-jobs/rally-noiro-neutron.yaml
@@ -1,0 +1,817 @@
+{% set image_name = "^cirros.*-disk$" %}
+{% set flavor_name = "m1.tiny" %}
+{% set smoke = 0 %}
+
+---
+  NeutronNetworks.create_and_list_networks:
+    -
+      args:
+        network_create_args: {}
+      runner:
+        type: "constant"
+        times: {{smoke or 8}}
+        concurrency: {{smoke or 4}}
+      context:
+        users:
+          tenants: {{smoke or 2}}
+          users_per_tenant: {{smoke or 1}}
+        quotas:
+          neutron:
+             network: -1
+      sla:
+        failure_rate:
+          max: 20
+    -
+      args:
+        network_create_args:
+          provider:network_type: "vxlan"
+      runner:
+        type: "constant"
+        times: {{smoke or 8}}
+        concurrency: {{smoke or 4}}
+      context:
+        users:
+          tenants: {{smoke or 2}}
+          users_per_tenant: {{smoke or 1}}
+        quotas:
+          neutron:
+             network: -1
+        roles:
+          - "admin"
+      sla:
+        failure_rate:
+          max: 20
+
+  NeutronNetworks.set_and_clear_router_gateway:
+    -
+      args:
+        network_create_args:
+          router:external: True
+        router_create_args: {}
+      runner:
+        type: "constant"
+        times: 4
+        concurrency: 2
+      context:
+        network: {}
+        users:
+          tenants: 2
+          users_per_tenant: 2
+        quotas:
+          neutron:
+            network: -1
+            router: -1
+        roles:
+          - "admin"
+      sla:
+        failure_rate:
+          max: 0
+
+  NeutronNetworks.create_and_show_network:
+    -
+      args:
+        network_create_args: {}
+      runner:
+        type: "constant"
+        times: {{smoke or 8}}
+        concurrency: {{smoke or 4}}
+      context:
+        users:
+          tenants: {{smoke or 2}}
+          users_per_tenant: {{smoke or 1}}
+        quotas:
+          neutron:
+            network: -1
+      sla:
+        failure_rate:
+          max: 0
+
+  NeutronNetworks.create_and_list_subnets:
+    -
+      args:
+        network_create_args:
+        subnet_create_args:
+        subnet_cidr_start: "1.1.0.0/30"
+        subnets_per_network: 2
+      runner:
+        type: "constant"
+        times: {{smoke or 8 }}
+        concurrency: {{smoke or 4}}
+      context:
+        network: {}
+        users:
+          tenants: {{smoke or 2}}
+          users_per_tenant: {{smoke or 1}}
+        quotas:
+          neutron:
+             network: -1
+             subnet: -1
+      sla:
+        failure_rate:
+          max: 20
+
+  NeutronNetworks.create_and_show_subnets:
+    -
+      args:
+        network_create_args:
+        subnet_create_args:
+        subnet_cidr_start: "1.1.0.0/30"
+        subnets_per_network: 2
+      runner:
+        type: "constant"
+        times: {{smoke or 8 }}
+        concurrency: {{smoke or 4}}
+      context:
+        network: {}
+        users:
+          tenants: {{smoke or 2}}
+          users_per_tenant: {{smoke or 1}}
+        quotas:
+          neutron:
+             network: -1
+             subnet: -1
+      sla:
+        failure_rate:
+          max: 20
+
+  NeutronSecurityGroup.create_and_list_security_groups:
+    -
+      args:
+        security_group_create_args: {}
+      runner:
+        type: "constant"
+        times: {{smoke or 8 }}
+        concurrency: {{smoke or 4}}
+      context:
+        users:
+          tenants: {{smoke or 2}}
+          users_per_tenant: {{smoke or 1}}
+        quotas:
+          neutron:
+            security_group: -1
+      sla:
+        failure_rate:
+          max: 20
+
+  NeutronSecurityGroup.create_and_show_security_group:
+    -
+      args:
+        security_group_create_args: {}
+      runner:
+        type: "constant"
+        times: {{smoke or 8 }}
+        concurrency: {{smoke or 4}}
+      context:
+        users:
+          tenants: {{smoke or 2}}
+          users_per_tenant: {{smoke or 1}}
+        quotas:
+          neutron:
+            security_group: -1
+      sla:
+        failure_rate:
+          max: 20
+
+  NeutronSecurityGroup.create_and_delete_security_groups:
+    -
+      args:
+        security_group_create_args: {}
+      runner:
+        type: "constant"
+        times: {{smoke or 8 }}
+        concurrency: {{smoke or 4}}
+      context:
+        users:
+          tenants: {{smoke or 2}}
+          users_per_tenant: {{smoke or 1}}
+        quotas:
+          neutron:
+            security_group: -1
+      sla:
+        failure_rate:
+          max: 20
+
+  NeutronSecurityGroup.create_and_update_security_groups:
+    -
+      args:
+        security_group_create_args: {}
+        security_group_update_args: {}
+      runner:
+        type: "constant"
+        times: {{smoke or 8 }}
+        concurrency: {{smoke or 4}}
+      context:
+        users:
+          tenants: {{smoke or 2}}
+          users_per_tenant: {{smoke or 1}}
+        quotas:
+          neutron:
+            security_group: -1
+      sla:
+        failure_rate:
+          max: 20
+
+  NeutronSecurityGroup.create_and_list_security_group_rules:
+    -
+      args:
+        security_group_args: {}
+        security_group_rule_args: {}
+      runner:
+        type: "constant"
+        times: {{smoke or 8 }}
+        concurrency: {{smoke or 4}}
+      context:
+        users:
+          tenants: {{smoke or 2}}
+          users_per_tenant: {{smoke or 1}}
+        quotas:
+          neutron:
+            security_group: -1
+      sla:
+        failure_rate:
+          max: 20
+
+  NeutronSecurityGroup.create_and_show_security_group_rule:
+    -
+      args:
+        security_group_args: {}
+        security_group_rule_args: {}
+      runner:
+        type: "constant"
+        times: 8
+        concurrency: 4
+      context:
+        users:
+          tenants: 2
+          users_per_tenant: 1
+        quotas:
+          neutron:
+            security_group: -1
+      sla:
+        failure_rate:
+          max: 0
+
+  NeutronSecurityGroup.create_and_delete_security_group_rule:
+    -
+      args:
+        security_group_args: {}
+        security_group_rule_args: {}
+      runner:
+        type: "constant"
+        times: 4
+        concurrency: 4
+      context:
+        users:
+          tenants: 2
+          users_per_tenant: 1
+      sla:
+        failure_rate:
+          max: 0
+
+  NeutronNetworks.create_and_list_floating_ips:
+    -
+      args:
+        floating_network: "l3out-2"
+        floating_ip_args: {}
+      runner:
+        type: "constant"
+        times: {{smoke or 8}}
+        concurrency: {{smoke or 4}}
+      context:
+        users:
+          tenants: {{smoke or 2}}
+          users_per_tenant: {{smoke or 1}}
+        quotas:
+          neutron:
+             floatingip: -1
+      sla:
+        failure_rate:
+          max: 0
+
+  NeutronNetworks.create_and_list_routers:
+    -
+      args:
+        network_create_args:
+        subnet_create_args:
+        subnet_cidr_start: "1.1.0.0/30"
+        subnets_per_network: 1
+        router_create_args:
+      runner:
+        type: "constant"
+        times: {{smoke or 8}}
+        concurrency: {{smoke or 4}}
+      context:
+        network: {}
+        users:
+          tenants: {{smoke or 2}}
+          users_per_tenant: {{smoke or 1}}
+        quotas:
+          neutron:
+             network: -1
+             subnet: -1
+             router: -1
+      sla:
+        failure_rate:
+          max: 20
+
+  NeutronNetworks.create_and_show_routers:
+    -
+      args:
+        subnet_cidr_start: "1.1.0.0/30"
+        subnets_per_network: 1
+      runner:
+        type: "constant"
+        times: 4
+        concurrency: 2
+      context:
+        network: {}
+        users:
+          tenants: 2
+          users_per_tenant: 2
+        quotas:
+          neutron:
+            network: -1
+            subnet: -1
+            router: -1
+
+  NeutronNetworks.create_and_list_ports:
+    -
+      args:
+        network_create_args:
+        port_create_args:
+        ports_per_network: 4
+      runner:
+        type: "constant"
+        times: {{smoke or 8}}
+        concurrency: {{smoke or 4}}
+      context:
+        network: {}
+        users:
+          tenants: {{smoke or 2}}
+          users_per_tenant: {{smoke or 1}}
+        quotas:
+          neutron:
+             network: -1
+             subnet: -1
+             router: -1
+             port: -1
+      sla:
+        failure_rate:
+          max: 20
+
+  NeutronNetworks.list_agents:
+    -
+      args:
+        agent_args: {}
+      runner:
+        type: "constant"
+        times: {{smoke or 4}}
+        concurrency: {{smoke or 2}}
+      context:
+        users:
+          tenants: {{smoke or 2}}
+          users_per_tenant: {{smoke or 1}}
+      sla:
+        failure_rate:
+          max: 0
+
+  NeutronNetworks.create_and_show_ports:
+    -
+      args:
+        network_create_args: {}
+        port_create_args: {}
+        ports_per_network: 2
+      runner:
+        type: "constant"
+        times: {{smoke or 4}}
+        concurrency: {{smoke or 2}}
+      context:
+        network: {}
+        users:
+          tenants: {{smoke or 2}}
+          users_per_tenant: {{smoke or 1}}
+        quotas:
+          neutron:
+            network: -1
+            port: -1
+      sla:
+        failure_rate:
+          max: 0
+
+  NeutronNetworks.create_and_update_networks:
+    -
+      args:
+        network_create_args: {}
+        network_update_args:
+            admin_state_up: False
+            name: "_updated"
+      runner:
+        type: "constant"
+        times: {{smoke or 8}}
+        concurrency: {{smoke or 4}}
+      context:
+        users:
+          tenants: {{smoke or 2}}
+          users_per_tenant: {{smoke or 1}}
+        quotas:
+          neutron:
+            network: -1
+      sla:
+        failure_rate:
+          max: 20
+
+  NeutronNetworks.create_and_update_subnets:
+    -
+      args:
+        network_create_args: {}
+        subnet_create_args: {}
+        subnet_cidr_start: "1.4.0.0/16"
+        subnets_per_network: 2
+        subnet_update_args:
+            enable_dhcp: False
+            name: "_subnet_updated"
+      runner:
+        type: "constant"
+        times: {{smoke or 8}}
+        concurrency: {{smoke or 4}}
+      context:
+        network: {}
+        users:
+          tenants: {{smoke or 2}}
+          users_per_tenant: {{smoke or 1}}
+        quotas:
+          neutron:
+            network: -1
+            subnet: -1
+      sla:
+        failure_rate:
+          max: 20
+
+  NeutronNetworks.create_and_update_routers:
+    -
+      args:
+        network_create_args: {}
+        subnet_create_args: {}
+        subnet_cidr_start: "1.1.0.0/30"
+        subnets_per_network: 1
+        router_create_args: {}
+        router_update_args:
+            admin_state_up: False
+            name: "_router_updated"
+      runner:
+        type: "constant"
+        times: {{smoke or 4}}
+        concurrency: {{smoke or 4}}
+      context:
+        network: {}
+        users:
+          tenants: {{smoke or 2}}
+          users_per_tenant: {{smoke or 1}}
+        quotas:
+          neutron:
+            network: -1
+            subnet: -1
+            router: -1
+      sla:
+        failure_rate:
+          max: 20
+
+  NeutronNetworks.create_and_delete_networks:
+    -
+      args:
+        network_create_args: {}
+      runner:
+        type: "constant"
+        times: {{smoke or 20}}
+        concurrency: {{smoke or 10}}
+      context:
+        users:
+          tenants: {{smoke or 3}}
+          users_per_tenant: {{smoke or 2}}
+        quotas:
+          neutron:
+            network: -1
+            subnet: -1
+      sla:
+        failure_rate:
+          max: 20
+
+  NeutronNetworks.create_and_delete_subnets:
+    -
+      args:
+        network_create_args: {}
+        subnet_create_args: {}
+        subnet_cidr_start: "1.1.0.0/30"
+        subnets_per_network: 2
+      runner:
+        type: "constant"
+        times: {{smoke or 8}}
+        concurrency: {{smoke or 4}}
+      context:
+        network: {}
+        users:
+          tenants: {{smoke or 3}}
+          users_per_tenant: {{smoke or 2}}
+        quotas:
+          neutron:
+            network: -1
+            subnet: -1
+      sla:
+        failure_rate:
+          max: 20
+
+  NeutronNetworks.create_and_delete_floating_ips:
+    -
+      args:
+        floating_network: "l3out-2"
+        floating_ip_args: {}
+      runner:
+        type: "constant"
+        times: {{smoke or 8}}
+        concurrency: {{smoke or 4}}
+      context:
+        users:
+          tenants: {{smoke or 2}}
+          users_per_tenant: {{smoke or 1}}
+        quotas:
+          neutron:
+             floatingip: -1
+      sla:
+        failure_rate:
+          max: 0
+
+  NeutronNetworks.create_and_delete_routers:
+    -
+      args:
+        network_create_args: {}
+        subnet_create_args: {}
+        subnet_cidr_start: "1.1.0.0/30"
+        subnets_per_network: 1
+        router_create_args: {}
+      runner:
+        type: "constant"
+        times: {{smoke or 4}}
+        concurrency: {{smoke or 4}}
+      context:
+        network: {}
+        users:
+          tenants: {{smoke or 2}}
+          users_per_tenant: {{smoke or 1}}
+        quotas:
+          neutron:
+            network: -1
+            subnet: -1
+            router: -1
+      sla:
+          failure_rate:
+            max: 20
+
+  NeutronNetworks.create_and_delete_ports:
+    -
+      args:
+        network_create_args: {}
+        port_create_args: {}
+        ports_per_network: 5
+      runner:
+        type: "constant"
+        times: {{smoke or 4}}
+        concurrency: {{smoke or 4}}
+      context:
+        network: {}
+        users:
+          tenants: {{smoke or 2}}
+          users_per_tenant: {{smoke or 1}}
+        quotas:
+          neutron:
+            network: -1
+            port: -1
+      sla:
+        failure_rate:
+          max: 20
+
+  NeutronNetworks.create_and_update_ports:
+    -
+      args:
+        network_create_args: {}
+        port_create_args: {}
+        ports_per_network: 2
+        port_update_args:
+            admin_state_up: False
+            device_id: "dummy_id"
+            device_owner: "dummy_owner"
+            name: "_port_updated"
+      runner:
+        type: "constant"
+        times: {{smoke or 10}}
+        concurrency: {{smoke or 5}}
+      context:
+        network: {}
+        users:
+          tenants: {{smoke or 2}}
+          users_per_tenant: {{smoke or 1}}
+        quotas:
+          neutron:
+            network: -1
+            port: -1
+      sla:
+        failure_rate:
+          max: 20
+
+  NeutronSubnets.delete_subnets:
+    -
+      runner:
+        type: "constant"
+        times: {{smoke or 15}}
+        concurrency: {{smoke or 15}}
+      context:
+        users:
+          tenants: 1
+          users_per_tenant: {{smoke or 15}}
+          user_choice_method: "round_robin"
+        quotas:
+          neutron:
+            network: -1
+            subnet: -1
+        network:
+          subnets_per_network: 15
+          dualstack: True
+          router: {}
+
+  Quotas.neutron_update:
+    -
+      args:
+        max_quota: 1024
+      runner:
+        type: "constant"
+        times: {{smoke or 10}}
+        concurrency: {{smoke or 2}}
+      context:
+        users:
+          tenants: {{smoke or 2}}
+          users_per_tenant: {{smoke or 1}}
+      sla:
+        failure_rate:
+          max: 0
+
+  NovaServers.boot_and_delete_server:
+    -
+      args:
+        auto_assign_nic: True
+        flavor:
+            name: "m1.tiny"
+        image:
+            name: {{image_name}}
+            list_kwargs:
+              visibility: "public"
+      runner:
+        type: "constant"
+        times: 1
+        concurrency: 1
+      context:
+        users:
+          tenants: 1
+          users_per_tenant: 1
+        network:
+          start_cidr: "10.2.0.0/24"
+          networks_per_tenant: 2
+          dns_nameservers:
+            - "8.8.8.8"
+            - "8.8.4.4"
+          router:
+            external: false
+      sla:
+        failure_rate:
+          max: 0
+
+  VMTasks.boot_runcommand_delete:
+    -
+      args:
+        flavor:
+            name: "m1.tiny"
+        image:
+            name: {{image_name}}
+        command:
+          script_file: "~/.rally/extra/instance_test.sh"
+          interpreter: "/bin/sh"
+        username: "cirros"
+      runner:
+        type: "constant"
+        times: {{smoke or 2}}
+        concurrency: {{smoke or 2}}
+      context:
+        users:
+          tenants: {{smoke or 2}}
+          users_per_tenant: {{smoke or 2}}
+        network: {}
+      sla:
+        failure_rate:
+          max: 0
+    -
+      args:
+        flavor:
+            name: "m1.tiny"
+        image:
+            name: {{image_name}}
+        command:
+          script_file: "~/.rally/extra/instance_test.sh"
+          interpreter: "/bin/sh"
+        username: "cirros"
+        volume_args:
+            size: 2
+      runner:
+        type: "constant"
+        times: {{smoke or 2}}
+        concurrency: {{smoke or 2}}
+      context:
+        users:
+          tenants: {{smoke or 2}}
+          users_per_tenant: {{smoke or 1}}
+        network: {}
+      sla:
+        failure_rate:
+          max: 0
+    -
+      args:
+        flavor:
+          name: {{flavor_name}}
+        image:
+          name: {{image_name}}
+        floating_network: "l3out-2"
+        command:
+          script_inline: |
+            time_seconds(){ (time -p $1 ) 2>&1 |awk '/real/{print $2}'; }
+            file=/tmp/test.img
+            c=100 #100M
+            write_seq=$(time_seconds "dd if=/dev/zero of=$file bs=1M count=$c")
+            read_seq=$(time_seconds "dd if=$file of=/dev/null bs=1M count=$c")
+            [ -f $file ] && rm $file
+
+            echo "{
+                \"write_seq\": $write_seq,
+                \"read_seq\": $read_seq
+                }"
+          interpreter: "/bin/sh"
+        username: "cirros"
+      runner:
+        type: "constant"
+        times: 2
+        concurrency: 2
+      context:
+        users:
+          tenants: 1
+          users_per_tenant: 1
+        network: {}
+      sla:
+        failure_rate:
+          max: 0
+    -
+      args:
+        command:
+          # The `image_command_customizer` context prepares an image and
+          # executes `rally-jobs/extra/install_benchmark.sh` script. The script
+          # itself creates a new file inside the image "dd_test.sh" which is
+          # called in the scenario. It doesn't have anything related to
+          # VMTask.dd_load_test scenario
+          remote_path: "./dd_test.sh"
+        flavor:
+          name: "m1.tiny"
+        username: "cirros"
+      runner:
+        type: "constant"
+        times: 1
+        concurrency: 1
+      context:
+        image_command_customizer:
+          command:
+            local_path: "~/.rally/extra/install_benchmark.sh"
+            remote_path: "./install_benchmark.sh"
+          flavor:
+            name: "m1.tiny"
+          image:
+            name: {{image_name}}
+          username: "cirros"
+        users:
+          tenants: 1
+          users_per_tenant: 1
+        network:
+          dns_nameservers: []
+
+  VMTasks.dd_load_test:
+    -
+      args:
+        flavor:
+            name: "m1.tiny"
+        image:
+            name: {{image_name}}
+        floating_network: "l3out-2"
+        force_delete: false
+        username: "cirros"
+      runner:
+        type: "constant"
+        times: 2
+        concurrency: 2
+      context:
+        users:
+          tenants: 2
+          users_per_tenant: 1
+        network: {}


### PR DESCRIPTION
This adds a rally job that can be used with the noironetworks
OpenStack Director/sauto installs on the noironetworks FABs.